### PR TITLE
bitstream: refactor Scope into an enum

### DIFF
--- a/llvm-bitstream/src/error.rs
+++ b/llvm-bitstream/src/error.rs
@@ -41,5 +41,5 @@ pub enum Error {
     BadAbbrev(u64),
     /// An error occurred during block scope entrance or exit.
     #[error("error while parsing block scope: {0}")]
-    Scope(String),
+    BadScope(String),
 }

--- a/llvm-bitstream/src/parser.rs
+++ b/llvm-bitstream/src/parser.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::iter;
 
 use llvm_bitcursor::BitCursor;
 
@@ -29,47 +30,80 @@ pub enum StreamEntry {
 }
 
 /// Represents the necessary parse state for a particular scope in the bitstream.
-/// Any given scope has two required pieces of state: the current code width for abbreviation
-/// IDs, and a list of [`Abbrev`](abbrev::Abbrev)s that apply to records in
-/// this scope.
-///
-/// In addition to the required state, a scope can have an optional block ID
-/// (if the scope corresponds directly to a block in the stream).
 ///
 /// Note that a scope does not *necessarily* correspond to a block: every
-/// parser begins with a default scope before the first block is encountered.
+/// parser begins with an initial non-block scope before the first block is encountered.
 #[derive(Debug)]
-struct Scope {
-    pub current_width: u64,
-    pub block_id: Option<u64>,
-    pub blockinfo_block_id: Option<u64>,
-    pub abbrevs: Vec<abbrev::Abbrev>,
+enum Scope {
+    Initial,
+    Block {
+        abbrev_id_width: u64,
+        block_id: u64,
+        blockinfo_block_id: Option<u64>,
+        abbrevs: Vec<abbrev::Abbrev>,
+    },
 }
 
 impl Default for Scope {
     fn default() -> Self {
-        Self {
-            current_width: 2,
-            block_id: None,
-            blockinfo_block_id: None,
-            abbrevs: vec![],
-        }
+        Self::Initial
     }
 }
 
 impl Scope {
-    pub(self) fn new(width: u64, id: u64) -> Self {
-        Self {
-            current_width: width,
-            block_id: Some(id),
+    /// Returns a new (block) scope.
+    pub(self) fn new(abbrev_id_width: u64, block_id: u64) -> Self {
+        Self::Block {
+            abbrev_id_width: abbrev_id_width,
+            block_id: block_id,
             blockinfo_block_id: None,
             abbrevs: vec![],
         }
     }
 
-    pub(self) fn get_abbrev(&self, abbrev_id: u64) -> Option<&abbrev::Abbrev> {
-        let idx = (abbrev_id as usize) - FIRST_APPLICATION_ABBREV_ID;
-        self.abbrevs.get(idx)
+    /// Returns the current width used for abbreviation IDs.
+    pub(self) fn abbrev_id_width(&self) -> u64 {
+        match self {
+            Scope::Initial => 2,
+            Scope::Block {
+                abbrev_id_width, ..
+            } => *abbrev_id_width,
+        }
+    }
+
+    /// Extend the current (block) scope's abbreviation definition list with the given
+    /// iterator.
+    ///
+    /// Returns an error if used on a non-block scope.
+    pub(self) fn extend_abbrevs(
+        &mut self,
+        new_abbrevs: impl iter::IntoIterator<Item = abbrev::Abbrev>,
+    ) -> Result<(), Error> {
+        match self {
+            Scope::Initial => Err(Error::BadScope(
+                "non-block scope cannot reference abbreviations".into(),
+            )),
+            Scope::Block { abbrevs, .. } => {
+                abbrevs.extend(new_abbrevs);
+                Ok(())
+            }
+        }
+    }
+
+    /// Return a reference to the abbreviation definition with the given `abbrev_id`.
+    ///
+    /// Returns an error if the scope cannot contain abbreviation definitions or does
+    /// not have one for the given ID.
+    pub(self) fn get_abbrev(&self, abbrev_id: u64) -> Result<&abbrev::Abbrev, Error> {
+        match self {
+            Scope::Initial => Err(Error::BadScope(
+                "non-block scope cannot contain records".into(),
+            )),
+            Scope::Block { abbrevs, .. } => {
+                let idx = (abbrev_id as usize) - FIRST_APPLICATION_ABBREV_ID;
+                abbrevs.get(idx).ok_or(Error::BadAbbrev(abbrev_id))
+            }
+        }
     }
 
     /// Returns `true` if this scope corresponds to a `BLOCKINFO` block.
@@ -77,19 +111,41 @@ impl Scope {
     /// This keeps the [`StreamParser`](StreamParser) honest when determining
     /// which blocks and/or records to emit entries for.
     pub(self) fn is_blockinfo(&self) -> bool {
-        self.block_id == Some(BlockId::BlockInfo as u64)
+        match self {
+            Scope::Initial => false,
+            Scope::Block { block_id, .. } => *block_id == BlockId::BlockInfo as u64,
+        }
     }
 
-    /// Returns `true` if this scope corresponds to *some* block in the stream.
+    /// Returns the last block ID recorded with `SETBID` in the `BLOCKINFO` block.
     ///
-    /// This is a necessary check for a well-formed bitstream: the parser
-    /// is generic and will happily accept a record outside of any block,
-    /// but this wouldn't be a correctly formed bitstream.
-    pub(self) fn corresponds_to_block(&self) -> bool {
-        // TODO(ww): This function shouldn't exist. Instead, `Scope`
-        // should be an enum of `Default | Block(...)` where the `Block(...)`
-        // scope contains block-relevant scope state (block ID, abbrevs, etc.).
-        self.block_id.is_some()
+    /// This function's return is only sensible in the context of a scope corresponding
+    /// to `BLOCKINFO`. Use on any other scope constitutes API misuse.
+    pub(self) fn blockinfo_block_id(&self) -> Option<u64> {
+        match self {
+            Scope::Initial => None,
+            Scope::Block {
+                blockinfo_block_id, ..
+            } => *blockinfo_block_id,
+        }
+    }
+
+    /// Sets the current block ID for the `BLOCKINFO` block's state machine.
+    ///
+    /// Returns an error if requested in a nonsense context, such as on any
+    /// non-`BLOCKINFO` scope.
+    pub(self) fn set_blockinfo_block_id(&mut self, new_bid: u64) -> Result<(), Error> {
+        if let Scope::Block {
+            blockinfo_block_id, ..
+        } = self
+        {
+            *blockinfo_block_id = Some(new_bid);
+            return Ok(());
+        }
+
+        Err(Error::BadScope(
+            "can't set BLOCKINFO block ID for non-BLOCKINFO scope".into(),
+        ))
     }
 }
 
@@ -147,7 +203,7 @@ impl<T: AsRef<[u8]>> StreamParser<T> {
         self.cursor.align32();
 
         if new_width < 1 {
-            return Err(Error::Scope(format!(
+            return Err(Error::BadScope(format!(
                 "can't enter block: invalid code side: {}",
                 new_width
             )));
@@ -170,7 +226,7 @@ impl<T: AsRef<[u8]>> StreamParser<T> {
 
         // If our blockinfo map contains any abbrevs for the current block ID, add them here.
         if let Some(abbrevs) = self.blockinfo.get(&block_id).map(|a| a.to_vec()) {
-            self.scope_mut().abbrevs.extend(abbrevs);
+            self.scope_mut().extend_abbrevs(abbrevs)?;
         }
 
         // If we've just entered a BLOCKINFO block, return `None` to avoid
@@ -194,7 +250,7 @@ impl<T: AsRef<[u8]>> StreamParser<T> {
         // NOTE(ww): We never allow an END_BLOCK to pop the last scope,
         // since the last scope is synthetic and does not correspond to a real block.
         if self.scopes.len() <= 1 {
-            return Err(Error::Scope(
+            return Err(Error::BadScope(
                 "malformed stream: cannot perform END_BLOCK because scope stack is empty".into(),
             ));
         }
@@ -218,21 +274,13 @@ impl<T: AsRef<[u8]>> StreamParser<T> {
         let abbrev = abbrev::Abbrev::new(&mut self.cursor)?;
         log::debug!("new abbrev: {:?}", abbrev);
 
-        // Sanity check: `DEFINE_ABBREV` can only occur inside a block,
-        // so the current scope must be a block.
-        if !self.scope().corresponds_to_block() {
-            return Err(Error::StreamParse(
-                "DEFINE_ABBREV outside of any block scope".into(),
-            ));
-        }
-
         // `DEFINE_ABBREV` occurs in two contexts: either in a `BLOCKINFO`
         // block (where it affects all blocks with block ID defined by the current `SETBID`),
         // or in any other block, where it affects only the current scope.
         // For the latter case we assume that any `BLOCKINFO`-defined abbrevs have
         // already been loaded into the current scope.
         if self.scope().is_blockinfo() {
-            let block_id = self.scope().blockinfo_block_id.ok_or_else(|| {
+            let block_id = self.scope().blockinfo_block_id().ok_or_else(|| {
                 Error::StreamParse("DEFINE_ABBREV in BLOCKINFO but no preceding SETBID".into())
             })?;
             self.blockinfo
@@ -240,7 +288,7 @@ impl<T: AsRef<[u8]>> StreamParser<T> {
                 .or_insert_with(Vec::new)
                 .push(abbrev);
         } else {
-            self.scope_mut().abbrevs.push(abbrev);
+            self.scope_mut().extend_abbrevs(iter::once(abbrev))?;
         }
 
         Ok(())
@@ -250,7 +298,7 @@ impl<T: AsRef<[u8]>> StreamParser<T> {
     fn parse_unabbrev(&mut self) -> Result<Option<StreamEntry>, Error> {
         // Sanity check: `UNABBREV_RECORD` can only occur inside a block,
         // so the current scope must be a block.
-        if !self.scope().corresponds_to_block() {
+        if matches!(self.scope(), Scope::Initial) {
             return Err(Error::StreamParse(
                 "UNABBREV_RECORD outside of any block scope".into(),
             ));
@@ -276,7 +324,7 @@ impl<T: AsRef<[u8]>> StreamParser<T> {
                 BlockInfoCode::SetBid => {
                     let block_id: u64 = record.values[0].clone().try_into()?;
                     log::debug!("SETBID: BLOCKINFO block ID is now {}", block_id);
-                    self.scope_mut().blockinfo_block_id = Some(block_id);
+                    self.scope_mut().set_blockinfo_block_id(block_id)?;
                 }
                 BlockInfoCode::BlockName => log::debug!("skipping BLOCKNAME code in BLOCKINFO"),
                 BlockInfoCode::SetRecordName => {
@@ -291,25 +339,13 @@ impl<T: AsRef<[u8]>> StreamParser<T> {
 
     /// Interpret a record using its corresponding abbreviation definition.
     fn parse_with_abbrev(&mut self, abbrev_id: u64) -> Result<Option<StreamEntry>, Error> {
-        // Sanity check: an abbreviated record can only occur inside a block,
-        // so the current scope must be a block.
-        if !self.scope().corresponds_to_block() {
-            return Err(Error::StreamParse(
-                "abbreviated record outside of any block scope".into(),
-            ));
-        }
-
         // To parse a record according to an abbreviation definition, we
         // fetch the corresponding abbreviation (failing if we don't have one),
         // then use the abbreviation for the parse.
         // TODO(ww): The clone at the end here is a little annoying, but we
         // need it to avoid mixing mutable and immutable borrows here.
         // There is absolutely a better way to do that.
-        let abbrev = self
-            .scope()
-            .get_abbrev(abbrev_id)
-            .ok_or(Error::BadAbbrev(abbrev_id))?
-            .clone();
+        let abbrev = self.scope().get_abbrev(abbrev_id)?.clone();
 
         let mut values = abbrev.parse(&mut self.cursor)?;
         log::debug!("parsed values: {:?}", values);
@@ -350,7 +386,7 @@ impl<T: AsRef<[u8]>> StreamParser<T> {
         // parse strategy and the kind of entry we return.
         let id: abbrev::AbbrevId = self
             .cursor
-            .read(self.scope().current_width as usize)?
+            .read(self.scope().abbrev_id_width() as usize)?
             .into();
         log::debug!("next entry ID: {:?}", id);
 

--- a/llvm-bitstream/src/parser.rs
+++ b/llvm-bitstream/src/parser.rs
@@ -64,6 +64,7 @@ impl Scope {
     /// Returns the current width used for abbreviation IDs.
     pub(self) fn abbrev_id_width(&self) -> u64 {
         match self {
+            // The initial abbreviation ID width is always 2.
             Scope::Initial => 2,
             Scope::Block {
                 abbrev_id_width, ..


### PR DESCRIPTION
This makes some of the error handling cleaner, and gives us some
better crate-public APIs for interacting with scopes.