### PR TITLE
mapper: refactor core mapping traits

### DIFF
--- a/llvm-constants/src/enums.rs
+++ b/llvm-constants/src/enums.rs
@@ -179,7 +179,7 @@ pub enum IdentificationCode {
 
 /// Codes for each record in `MODULE_BLOCK`.
 #[non_exhaustive]
-#[derive(Copy, Clone, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u64)]
 pub enum ModuleCode {
     /// MODULE_CODE_VERSION: `[version#]`

--- a/llvm-constants/src/enums.rs
+++ b/llvm-constants/src/enums.rs
@@ -228,7 +228,6 @@ pub enum ModuleCode {
 }
 
 /// Codes for each record in `TYPE_BLOCK` (i.e., `TYPE_BLOCK_ID_NEW`).
-#[non_exhaustive]
 #[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u64)]
 pub enum TypeCode {
@@ -305,7 +304,6 @@ pub enum SymtabCode {
 /// Codes for each record in `PARAMATTR_BLOCK` or `PARAMATTR_GROUP_BLOCK`.
 // NOTE(ww): For whatever reason, these two blocks share the same enum for
 // record codes.
-#[non_exhaustive]
 #[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u64)]
 pub enum AttributeCode {

--- a/llvm-constants/src/enums.rs
+++ b/llvm-constants/src/enums.rs
@@ -179,7 +179,7 @@ pub enum IdentificationCode {
 
 /// Codes for each record in `MODULE_BLOCK`.
 #[non_exhaustive]
-#[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[derive(Copy, Clone, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u64)]
 pub enum ModuleCode {
     /// MODULE_CODE_VERSION: `[version#]`

--- a/llvm-constants/src/enums.rs
+++ b/llvm-constants/src/enums.rs
@@ -1,6 +1,6 @@
 //! Enum constants for `llvm-constants`.
 
-use num_enum::TryFromPrimitive;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::constants::FIRST_APPLICATION_BLOCK_ID;
 
@@ -179,7 +179,7 @@ pub enum IdentificationCode {
 
 /// Codes for each record in `MODULE_BLOCK`.
 #[non_exhaustive]
-#[derive(Debug, PartialEq, TryFromPrimitive)]
+#[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u64)]
 pub enum ModuleCode {
     /// MODULE_CODE_VERSION: `[version#]`
@@ -229,7 +229,7 @@ pub enum ModuleCode {
 
 /// Codes for each record in `TYPE_BLOCK` (i.e., `TYPE_BLOCK_ID_NEW`).
 #[non_exhaustive]
-#[derive(Debug, PartialEq, TryFromPrimitive)]
+#[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u64)]
 pub enum TypeCode {
     /// TYPE_CODE_NUMENTRY: `[numentries]`
@@ -286,7 +286,7 @@ pub enum TypeCode {
 
 /// Codes for each record in `STRTAB_BLOCK`.
 #[non_exhaustive]
-#[derive(Debug, PartialEq, TryFromPrimitive)]
+#[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u64)]
 pub enum StrtabCode {
     /// STRTAB_BLOB: `[...string...]`
@@ -295,7 +295,7 @@ pub enum StrtabCode {
 
 /// Codes for each record in `SYMTAB_BLOCK`.
 #[non_exhaustive]
-#[derive(Debug, PartialEq, TryFromPrimitive)]
+#[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u64)]
 pub enum SymtabCode {
     /// SYMTAB_BLOB: `[...data...]`
@@ -306,7 +306,7 @@ pub enum SymtabCode {
 // NOTE(ww): For whatever reason, these two blocks share the same enum for
 // record codes.
 #[non_exhaustive]
-#[derive(Debug, PartialEq, TryFromPrimitive)]
+#[derive(Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u64)]
 pub enum AttributeCode {
     /// PARAMATTR_CODE_ENTRY_OLD: `[paramidx0, attr0, paramidx1, attr1...]`

--- a/llvm-mapper/src/block/attributes.rs
+++ b/llvm-mapper/src/block/attributes.rs
@@ -460,7 +460,7 @@ impl IrBlock for Attributes {
                 }
                 AttributeCode::GroupCodeEntry => {
                     // This is a valid attribute code, but it isn't valid in this block.
-                    return Err(AttributeError::WrongBlock(code).into());
+                    return Err(AttributeError::WrongBlock(code));
                 }
             }
         }
@@ -522,13 +522,13 @@ impl IrBlock for AttributeGroups {
             let code = AttributeCode::try_from(record.code()).map_err(AttributeError::from)?;
 
             if code != AttributeCode::GroupCodeEntry {
-                return Err(AttributeError::WrongBlock(code).into());
+                return Err(AttributeError::WrongBlock(code));
             }
 
             // Structure: [grpid, paramidx, <attr0>, <attr1>, ...]
             // Every group record must have at least one attribute.
             if record.fields().len() < 3 {
-                return Err(AttributeError::GroupTooShort(code, record.fields().len()).into());
+                return Err(AttributeError::GroupTooShort(code, record.fields().len()));
             }
 
             // Panic safety: We check for at least three fields above.
@@ -548,9 +548,10 @@ impl IrBlock for AttributeGroups {
 
             // Sanity check: we should have consumed every single record.
             if fieldidx != record.fields().len() {
-                return Err(
-                    AttributeError::GroupSizeMismatch(fieldidx, record.fields().len()).into(),
-                );
+                return Err(AttributeError::GroupSizeMismatch(
+                    fieldidx,
+                    record.fields().len(),
+                ));
             }
 
             groups.insert(

--- a/llvm-mapper/src/block/attributes.rs
+++ b/llvm-mapper/src/block/attributes.rs
@@ -9,7 +9,7 @@ use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
 use thiserror::Error;
 
 use crate::block::{BlockMapError, IrBlock};
-use crate::map::MapCtx;
+use crate::map::PartialMapCtx;
 use crate::record::RecordMapError;
 use crate::unroll::{UnrolledBlock, UnrolledRecord};
 
@@ -406,7 +406,10 @@ pub struct Attributes(Vec<AttributeEntry>);
 impl IrBlock for Attributes {
     const BLOCK_ID: IrBlockId = IrBlockId::ParamAttr;
 
-    fn try_map_inner(block: &UnrolledBlock, ctx: &mut MapCtx) -> Result<Self, BlockMapError> {
+    fn try_map_inner(
+        block: &UnrolledBlock,
+        ctx: &mut PartialMapCtx,
+    ) -> Result<Self, BlockMapError> {
         let mut entries = vec![];
 
         for record in block.all_records() {
@@ -488,7 +491,10 @@ impl AttributeGroups {
 impl IrBlock for AttributeGroups {
     const BLOCK_ID: IrBlockId = IrBlockId::ParamAttrGroup;
 
-    fn try_map_inner(block: &UnrolledBlock, _ctx: &mut MapCtx) -> Result<Self, BlockMapError> {
+    fn try_map_inner(
+        block: &UnrolledBlock,
+        _ctx: &mut PartialMapCtx,
+    ) -> Result<Self, BlockMapError> {
         let mut groups = HashMap::new();
 
         for record in block.all_records() {

--- a/llvm-mapper/src/block/attributes.rs
+++ b/llvm-mapper/src/block/attributes.rs
@@ -403,6 +403,12 @@ pub struct AttributeEntry(Vec<AttributeGroup>);
 #[derive(Debug)]
 pub struct Attributes(Vec<AttributeEntry>);
 
+impl Attributes {
+    pub(crate) fn get(&self, id: u64) -> Option<&AttributeEntry> {
+        self.0.get(id as usize)
+    }
+}
+
 impl IrBlock for Attributes {
     const BLOCK_ID: IrBlockId = IrBlockId::ParamAttr;
 
@@ -483,7 +489,7 @@ pub struct AttributeGroup {
 pub struct AttributeGroups(HashMap<u32, AttributeGroup>);
 
 impl AttributeGroups {
-    fn get(&self, group_id: u32) -> Option<&AttributeGroup> {
+    pub(crate) fn get(&self, group_id: u32) -> Option<&AttributeGroup> {
         self.0.get(&group_id)
     }
 }

--- a/llvm-mapper/src/block/attributes.rs
+++ b/llvm-mapper/src/block/attributes.rs
@@ -433,7 +433,7 @@ impl IrBlock for Attributes {
     ) -> Result<Self, BlockMapError> {
         let mut entries = vec![];
 
-        for record in block.all_records() {
+        for record in block.records() {
             let code = AttributeCode::try_from(record.code()).map_err(AttributeError::from)?;
 
             match code {
@@ -518,7 +518,7 @@ impl IrBlock for AttributeGroups {
     ) -> Result<Self, BlockMapError> {
         let mut groups = HashMap::new();
 
-        for record in block.all_records() {
+        for record in block.records() {
             let code = AttributeCode::try_from(record.code()).map_err(AttributeError::from)?;
 
             if code != AttributeCode::GroupCodeEntry {

--- a/llvm-mapper/src/block/identification.rs
+++ b/llvm-mapper/src/block/identification.rs
@@ -3,8 +3,8 @@
 use llvm_constants::{IdentificationCode, IrBlockId};
 use thiserror::Error;
 
-use crate::block::{BlockMapError, IrBlock};
-use crate::map::PartialMapCtx;
+use crate::block::IrBlock;
+use crate::map::{MapError, PartialMapCtx};
 use crate::unroll::UnrolledBlock;
 
 /// Errors that can occur while mapping the identification block.
@@ -21,6 +21,10 @@ pub enum IdentificationError {
     /// The `IDENTIFICATION_CODE_EPOCH` couldn't be found.
     #[error("identification block has no epoch")]
     MissingEpoch,
+
+    /// A generic mapping error occured.
+    #[error("mapping error in string table")]
+    Map(#[from] MapError),
 }
 
 /// Models the `IDENTIFICATION_BLOCK` block.
@@ -34,12 +38,11 @@ pub struct Identification {
 }
 
 impl IrBlock for Identification {
+    type Error = IdentificationError;
+
     const BLOCK_ID: IrBlockId = IrBlockId::Identification;
 
-    fn try_map_inner(
-        block: &UnrolledBlock,
-        _ctx: &mut PartialMapCtx,
-    ) -> Result<Self, BlockMapError> {
+    fn try_map_inner(block: &UnrolledBlock, _ctx: &mut PartialMapCtx) -> Result<Self, Self::Error> {
         let producer = block
             .records()
             .one(IdentificationCode::ProducerString as u64)

--- a/llvm-mapper/src/block/identification.rs
+++ b/llvm-mapper/src/block/identification.rs
@@ -1,11 +1,20 @@
 //! Functionality for mapping the `IDENTIFICATION_BLOCK` block.
 
 use llvm_constants::{IdentificationCode, IrBlockId};
+use thiserror::Error;
 
 use crate::block::{BlockMapError, IrBlock};
 use crate::map::PartialMapCtx;
 use crate::record::RecordMapError;
 use crate::unroll::UnrolledBlock;
+
+/// Errors that can occur while mapping the identification block.
+#[derive(Debug, Error)]
+pub enum IdentificationError {
+    /// The `IDENTIFICATION_CODE_EPOCH` couldn't be found.
+    #[error("identification block has no epoch")]
+    MissingEpoch,
+}
 
 /// Models the `IDENTIFICATION_BLOCK` block.
 #[non_exhaustive]
@@ -33,7 +42,10 @@ impl IrBlock for Identification {
         let epoch = {
             let epoch = block.one_record(IdentificationCode::Epoch as u64)?;
 
-            epoch.get_field(0)?
+            *epoch
+                .fields()
+                .get(0)
+                .ok_or(IdentificationError::MissingEpoch)?
         };
 
         Ok(Self { producer, epoch })

--- a/llvm-mapper/src/block/identification.rs
+++ b/llvm-mapper/src/block/identification.rs
@@ -3,7 +3,7 @@
 use llvm_constants::{IdentificationCode, IrBlockId};
 
 use crate::block::{BlockMapError, IrBlock};
-use crate::map::MapCtx;
+use crate::map::PartialMapCtx;
 use crate::record::RecordMapError;
 use crate::unroll::UnrolledBlock;
 
@@ -20,7 +20,10 @@ pub struct Identification {
 impl IrBlock for Identification {
     const BLOCK_ID: IrBlockId = IrBlockId::Identification;
 
-    fn try_map_inner(block: &UnrolledBlock, _ctx: &mut MapCtx) -> Result<Self, BlockMapError> {
+    fn try_map_inner(
+        block: &UnrolledBlock,
+        _ctx: &mut PartialMapCtx,
+    ) -> Result<Self, BlockMapError> {
         let producer = {
             let producer = block.one_record(IdentificationCode::ProducerString as u64)?;
 

--- a/llvm-mapper/src/block/mod.rs
+++ b/llvm-mapper/src/block/mod.rs
@@ -18,7 +18,7 @@ pub use self::module::*;
 pub use self::strtab::*;
 pub use self::symtab::*;
 pub use self::type_table::*;
-use crate::map::{MapCtx, MapCtxError, Mappable};
+use crate::map::{MapCtxError, PartialCtxMappable, PartialMapCtx};
 use crate::record::RecordMapError;
 use crate::unroll::UnrolledBlock;
 
@@ -90,13 +90,14 @@ pub(crate) trait IrBlock: Sized {
     /// Attempt to map the given block to the implementing type, returning an error if mapping fails.
     ///
     /// This is an interior trait that shouldn't be used directly.
-    fn try_map_inner(block: &UnrolledBlock, ctx: &mut MapCtx) -> Result<Self, BlockMapError>;
+    fn try_map_inner(block: &UnrolledBlock, ctx: &mut PartialMapCtx)
+        -> Result<Self, BlockMapError>;
 }
 
-impl<T: IrBlock> Mappable<UnrolledBlock> for T {
+impl<T: IrBlock> PartialCtxMappable<UnrolledBlock> for T {
     type Error = BlockMapError;
 
-    fn try_map(block: &UnrolledBlock, ctx: &mut MapCtx) -> Result<Self, Self::Error> {
+    fn try_map(block: &UnrolledBlock, ctx: &mut PartialMapCtx) -> Result<Self, Self::Error> {
         if block.id != BlockId::Ir(T::BLOCK_ID) {
             return Err(BlockMapError::BadBlockMap(format!(
                 "can't map {:?} into {:?}",

--- a/llvm-mapper/src/block/mod.rs
+++ b/llvm-mapper/src/block/mod.rs
@@ -126,6 +126,26 @@ impl<T: IrBlock> PartialCtxMappable<UnrolledBlock> for T {
     }
 }
 
+// impl<T: IrBlock> PartialCtxMappable<UnrolledBlock> for T
+// where
+//     T::Error: From<BlockMapError>,
+// {
+//     type Error = T::Error;
+
+//     fn try_map(block: &UnrolledBlock, ctx: &mut PartialMapCtx) -> Result<Self, Self::Error> {
+//         if block.id != BlockId::Ir(T::BLOCK_ID) {
+//             return Err(BlockMapError::BadBlockMap(format!(
+//                 "can't map {:?} into {:?}",
+//                 block.id,
+//                 Identification::BLOCK_ID
+//             ))
+//             .into());
+//         }
+
+//         IrBlock::try_map_inner(block, ctx)
+//     }
+// }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/llvm-mapper/src/block/mod.rs
+++ b/llvm-mapper/src/block/mod.rs
@@ -20,7 +20,7 @@ pub use self::symtab::*;
 pub use self::type_table::*;
 use crate::map::{MapCtxError, PartialCtxMappable, PartialMapCtx};
 use crate::record::RecordMapError;
-use crate::unroll::UnrolledBlock;
+use crate::unroll::{ConsistencyError, UnrolledBlock};
 
 /// Potential errors when mapping a single bitstream block.
 #[non_exhaustive]
@@ -37,14 +37,6 @@ pub enum BlockMapError {
     /// We couldn't map a block, for any number of reasons.
     #[error("error while mapping block: {0}")]
     BadBlockMap(String),
-
-    /// We expected exactly one record with this code in this block.
-    #[error("expected exactly one record of code {0} in block {1:?}")]
-    BlockRecordMismatch(u64, BlockId),
-
-    /// We expected exactly one sub-block with this ID in this block.
-    #[error("expected exactly one block of ID {0:?} in block {1:?}")]
-    BlockBlockMismatch(BlockId, BlockId),
 
     /// We couldn't map the identification block.
     #[error("error while mapping identification block")]
@@ -73,6 +65,10 @@ pub enum BlockMapError {
     /// We encountered an unsupported feature or layout.
     #[error("unsupported: {0}")]
     Unsupported(String),
+
+    /// The module has an invalid block or record state.
+    #[error("invalid block or record in module")]
+    Invalid(#[from] ConsistencyError),
 }
 
 /// A holistic model of all possible block IDs, spanning reserved, IR, and unknown IDs.

--- a/llvm-mapper/src/block/mod.rs
+++ b/llvm-mapper/src/block/mod.rs
@@ -46,6 +46,22 @@ pub enum BlockMapError {
     #[error("expected exactly one block of ID {0:?} in block {1:?}")]
     BlockBlockMismatch(BlockId, BlockId),
 
+    /// We couldn't map the identification block.
+    #[error("error while mapping identification block")]
+    BadIdentification(#[from] IdentificationError),
+
+    /// We couldn't map the module block.
+    #[error("error while mapping module")]
+    BadModule(#[from] ModuleError),
+
+    /// We couldn't map the string table.
+    #[error("error while mapping string table")]
+    BadStrtab(#[from] StrtabError),
+
+    /// We couldn't map the symbol table.
+    #[error("error while mapping symbol table")]
+    BadSymtab(#[from] SymtabError),
+
     /// We couldn't map the type table.
     #[error("error while mapping type table")]
     BadTypeTable(#[from] TypeTableError),

--- a/llvm-mapper/src/block/module.rs
+++ b/llvm-mapper/src/block/module.rs
@@ -67,7 +67,7 @@ impl IrBlock for Module {
         // Build the section table. We'll reference this later.
         let _section_table = block
             .records()
-            .by_code(ModuleCode::SectionName as u64)
+            .by_code(ModuleCode::SectionName)
             .map(|rec| rec.try_string(0))
             .collect::<Result<Vec<_>, _>>()
             .map_err(RecordMapError::from)?;
@@ -75,7 +75,7 @@ impl IrBlock for Module {
         // Build the GC table. We'll reference this later.
         let _gc_table = block
             .records()
-            .by_code(ModuleCode::GcName as u64)
+            .by_code(ModuleCode::GcName)
             .map(|rec| rec.try_string(0))
             .collect::<Result<Vec<_>, _>>()
             .map_err(RecordMapError::from)?;
@@ -131,7 +131,7 @@ impl IrBlock for Module {
         // Deplib records are deprecated, but we might be parsing an older bitstream.
         let deplibs = block
             .records()
-            .by_code(ModuleCode::DepLib as u64)
+            .by_code(ModuleCode::DepLib)
             .map(|rec| rec.try_string(0))
             .collect::<Result<Vec<_>, _>>()
             .map_err(RecordMapError::from)?;
@@ -139,7 +139,7 @@ impl IrBlock for Module {
         // Build the Comdat list. We'll reference this later.
         let _comdats = block
             .records()
-            .by_code(ModuleCode::Comdat as u64)
+            .by_code(ModuleCode::Comdat)
             .map(|rec| Comdat::try_map(rec, &ctx))
             .collect::<Result<Vec<_>, _>>()
             .map_err(RecordMapError::from)?;
@@ -147,7 +147,7 @@ impl IrBlock for Module {
         // Collect the function records and blocks in this module.
         let functions = block
             .records()
-            .by_code(ModuleCode::Function as u64)
+            .by_code(ModuleCode::Function)
             .map(|rec| FunctionRecord::try_map(rec, &ctx))
             .collect::<Result<Vec<_>, _>>()
             .map_err(RecordMapError::from)?;

--- a/llvm-mapper/src/block/module.rs
+++ b/llvm-mapper/src/block/module.rs
@@ -3,11 +3,14 @@
 use llvm_constants::{IrBlockId, ModuleCode, TARGET_TRIPLE};
 use thiserror::Error;
 
-use crate::block::attributes::{AttributeGroups, Attributes};
-use crate::block::type_table::TypeTable;
-use crate::block::{BlockId, BlockMapError, IrBlock};
-use crate::map::{CtxMappable, PartialCtxMappable, PartialMapCtx};
-use crate::record::{Comdat, DataLayout, Function as FunctionRecord, RecordMapError};
+use crate::block::attributes::{AttributeError, AttributeGroups, Attributes};
+use crate::block::type_table::{TypeTable, TypeTableError};
+use crate::block::{BlockId, IrBlock};
+use crate::map::{CtxMappable, MapError, PartialCtxMappable, PartialMapCtx};
+use crate::record::{
+    Comdat, ComdatError, DataLayout, DataLayoutError, Function as FunctionRecord,
+    FunctionError as FunctionRecordError,
+};
 use crate::unroll::UnrolledBlock;
 
 /// Errors that can occur while mapping a module.
@@ -16,6 +19,30 @@ pub enum ModuleError {
     /// The `MODULE_CODE_VERSION` couldn't be found.
     #[error("bitcode module has no version")]
     MissingVersion,
+
+    /// An error occured while mapping the datalayout record.
+    #[error("invalid datalayout record")]
+    DataLayoutRecord(#[from] DataLayoutError),
+
+    /// An error occurred while mapping the type table block.
+    #[error("invalid type table block")]
+    TypeTableBlock(#[from] TypeTableError),
+
+    /// An error occurred while mapping one of the attribute blocks.
+    #[error("invalid attribute block")]
+    AttributeBlock(#[from] AttributeError),
+
+    /// An error occurred while mapping a COMDAT record.
+    #[error("invalid COMDAT record")]
+    ComdatRecord(#[from] ComdatError),
+
+    /// An error occurred while mapping a function record.
+    #[error("invalid function record")]
+    FunctionRecord(#[from] FunctionRecordError),
+
+    /// A generic mapping error occurred.
+    #[error("mapping error in string table")]
+    Map(#[from] MapError),
 }
 
 /// Models the `MODULE_BLOCK` block.
@@ -31,23 +58,29 @@ pub struct Module {
 }
 
 impl IrBlock for Module {
+    type Error = ModuleError;
+
     const BLOCK_ID: IrBlockId = IrBlockId::Module;
 
-    fn try_map_inner(
-        block: &UnrolledBlock,
-        ctx: &mut PartialMapCtx,
-    ) -> Result<Self, BlockMapError> {
+    fn try_map_inner(block: &UnrolledBlock, ctx: &mut PartialMapCtx) -> Result<Self, Self::Error> {
         // Mapping the module requires us to fill in the `PartialMapCtx` first,
         // so we can reify it into a `MapCtx` for subsequent steps.
         ctx.version = Some({
-            let version = block.records().exactly_one(ModuleCode::Version)?;
+            let version = block
+                .records()
+                .exactly_one(ModuleCode::Version)
+                .map_err(MapError::Inconsistent)?;
 
             *version.fields().get(0).ok_or(ModuleError::MissingVersion)?
         });
 
         // Each module *should* have a datalayout record, but doesn't necessarily.
-        if let Some(record) = block.records().one_or_none(ModuleCode::DataLayout)? {
-            ctx.datalayout = DataLayout::try_map(record, ctx).map_err(RecordMapError::from)?;
+        if let Some(record) = block
+            .records()
+            .one_or_none(ModuleCode::DataLayout)
+            .map_err(MapError::Inconsistent)?
+        {
+            ctx.datalayout = DataLayout::try_map(record, ctx)?;
         }
 
         // Build the section table. We'll reference this later.
@@ -56,7 +89,7 @@ impl IrBlock for Module {
             .by_code(ModuleCode::SectionName)
             .map(|rec| rec.try_string(0))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(RecordMapError::from)?;
+            .map_err(MapError::RecordString)?;
 
         // Build the GC table. We'll reference this later.
         let _gc_table = block
@@ -64,11 +97,14 @@ impl IrBlock for Module {
             .by_code(ModuleCode::GcName)
             .map(|rec| rec.try_string(0))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(RecordMapError::from)?;
+            .map_err(MapError::RecordString)?;
 
         // Build the type table.
         ctx.type_table = Some(TypeTable::try_map(
-            block.blocks().exactly_one(BlockId::Ir(IrBlockId::Type))?,
+            block
+                .blocks()
+                .exactly_one(BlockId::Ir(IrBlockId::Type))
+                .map_err(MapError::Inconsistent)?,
             ctx,
         )?);
 
@@ -78,33 +114,43 @@ impl IrBlock for Module {
         // Neither block is mandatory.
         ctx.attribute_groups = block
             .blocks()
-            .one_or_none(BlockId::Ir(IrBlockId::ParamAttrGroup))?
+            .one_or_none(BlockId::Ir(IrBlockId::ParamAttrGroup))
+            .map_err(MapError::Inconsistent)?
             .map(|b| AttributeGroups::try_map(b, ctx))
             .transpose()?;
 
         ctx.attributes = block
             .blocks()
-            .one_or_none(BlockId::Ir(IrBlockId::ParamAttr))?
+            .one_or_none(BlockId::Ir(IrBlockId::ParamAttr))
+            .map_err(MapError::Inconsistent)?
             .map(|b| Attributes::try_map(b, ctx))
             .transpose()?;
 
         log::debug!("attributes: {:?}", ctx.attributes);
 
         // After this point, `ctx` refers to a fully reified `MapCtx`.
-        let ctx = ctx.reify()?;
+        let ctx = ctx.reify().map_err(MapError::Context)?;
 
         // Each module *should* have a target triple, but doesn't necessarily.
-        let triple = match block.records().one_or_none(ModuleCode::Triple)? {
-            Some(record) => record.try_string(0).map_err(RecordMapError::from)?,
+        let triple = match block
+            .records()
+            .one_or_none(ModuleCode::Triple)
+            .map_err(MapError::Inconsistent)?
+        {
+            Some(record) => record.try_string(0).map_err(MapError::RecordString)?,
             None => TARGET_TRIPLE.into(),
         };
 
         // Each module has zero or exactly one MODULE_CODE_ASM records.
-        let asm = match block.records().one_or_none(ModuleCode::Asm)? {
+        let asm = match block
+            .records()
+            .one_or_none(ModuleCode::Asm)
+            .map_err(MapError::Inconsistent)?
+        {
             None => Vec::new(),
             Some(record) => record
                 .try_string(0)
-                .map_err(RecordMapError::from)?
+                .map_err(MapError::RecordString)?
                 .split('\n')
                 .map(String::from)
                 .collect::<Vec<_>>(),
@@ -116,23 +162,21 @@ impl IrBlock for Module {
             .by_code(ModuleCode::DepLib)
             .map(|rec| rec.try_string(0))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(RecordMapError::from)?;
+            .map_err(MapError::RecordString)?;
 
         // Build the Comdat list. We'll reference this later.
         let _comdats = block
             .records()
             .by_code(ModuleCode::Comdat)
             .map(|rec| Comdat::try_map(rec, &ctx))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(RecordMapError::from)?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         // Collect the function records and blocks in this module.
         let functions = block
             .records()
             .by_code(ModuleCode::Function)
             .map(|rec| FunctionRecord::try_map(rec, &ctx))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(RecordMapError::from)?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         log::debug!("functions: {:?}", functions);
 

--- a/llvm-mapper/src/block/strtab.rs
+++ b/llvm-mapper/src/block/strtab.rs
@@ -7,7 +7,7 @@ use llvm_support::StrtabRef;
 use thiserror::Error;
 
 use crate::block::{BlockMapError, IrBlock};
-use crate::map::MapCtx;
+use crate::map::PartialMapCtx;
 use crate::unroll::{UnrolledBlock, UnrolledRecord};
 
 /// Errors that can occur when accessing a string table.
@@ -34,7 +34,10 @@ impl AsRef<[u8]> for Strtab {
 impl IrBlock for Strtab {
     const BLOCK_ID: IrBlockId = IrBlockId::Strtab;
 
-    fn try_map_inner(block: &UnrolledBlock, _ctx: &mut MapCtx) -> Result<Self, BlockMapError> {
+    fn try_map_inner(
+        block: &UnrolledBlock,
+        _ctx: &mut PartialMapCtx,
+    ) -> Result<Self, BlockMapError> {
         // TODO(ww): The docs also claim that there's only one STRTAB_BLOB per STRTAB_BLOCK,
         // but at least one person has reported otherwise here:
         // https://lists.llvm.org/pipermail/llvm-dev/2020-August/144327.html

--- a/llvm-mapper/src/block/symtab.rs
+++ b/llvm-mapper/src/block/symtab.rs
@@ -3,7 +3,7 @@
 use llvm_constants::{IrBlockId, SymtabCode};
 
 use crate::block::{BlockMapError, IrBlock};
-use crate::map::MapCtx;
+use crate::map::PartialMapCtx;
 use crate::unroll::UnrolledBlock;
 
 /// Models the `SYMTAB_BLOCK` block.
@@ -22,7 +22,10 @@ impl AsRef<[u8]> for Symtab {
 impl IrBlock for Symtab {
     const BLOCK_ID: IrBlockId = IrBlockId::Symtab;
 
-    fn try_map_inner(block: &UnrolledBlock, _ctx: &mut MapCtx) -> Result<Self, BlockMapError> {
+    fn try_map_inner(
+        block: &UnrolledBlock,
+        _ctx: &mut PartialMapCtx,
+    ) -> Result<Self, BlockMapError> {
         let symtab = {
             let symtab = block.one_record(SymtabCode::Blob as u64)?;
 

--- a/llvm-mapper/src/block/symtab.rs
+++ b/llvm-mapper/src/block/symtab.rs
@@ -11,6 +11,10 @@ use crate::unroll::UnrolledBlock;
 /// Errors that can occur when accessing a symbol table.
 #[derive(Debug, Error)]
 pub enum SymtabError {
+    /// The symbol table is missing its blob.
+    #[error("malformed symbol table: missing blob")]
+    MissingBlob,
+
     /// The blob containing the symbol table is invalid.
     #[error("invalid string table: {0}")]
     BadBlob(#[from] RecordBlobError),
@@ -36,11 +40,11 @@ impl IrBlock for Symtab {
         block: &UnrolledBlock,
         _ctx: &mut PartialMapCtx,
     ) -> Result<Self, BlockMapError> {
-        let symtab = {
-            let symtab = block.one_record(SymtabCode::Blob as u64)?;
-
-            symtab.try_blob(0).map_err(SymtabError::from)?
-        };
+        let symtab = block
+            .records()
+            .one(SymtabCode::Blob as u64)
+            .ok_or(SymtabError::MissingBlob)
+            .and_then(|r| r.try_blob(0).map_err(SymtabError::from))?;
 
         Ok(Self(symtab))
     }

--- a/llvm-mapper/src/block/symtab.rs
+++ b/llvm-mapper/src/block/symtab.rs
@@ -1,10 +1,20 @@
 //! Functionality for mapping the `SYMTAB_BLOCK` block.
 
 use llvm_constants::{IrBlockId, SymtabCode};
+use thiserror::Error;
 
 use crate::block::{BlockMapError, IrBlock};
 use crate::map::PartialMapCtx;
+use crate::record::RecordBlobError;
 use crate::unroll::UnrolledBlock;
+
+/// Errors that can occur when accessing a symbol table.
+#[derive(Debug, Error)]
+pub enum SymtabError {
+    /// The blob containing the symbol table is invalid.
+    #[error("invalid string table: {0}")]
+    BadBlob(#[from] RecordBlobError),
+}
 
 /// Models the `SYMTAB_BLOCK` block.
 ///
@@ -29,7 +39,7 @@ impl IrBlock for Symtab {
         let symtab = {
             let symtab = block.one_record(SymtabCode::Blob as u64)?;
 
-            symtab.try_blob(0)?
+            symtab.try_blob(0).map_err(SymtabError::from)?
         };
 
         Ok(Self(symtab))

--- a/llvm-mapper/src/block/type_table.rs
+++ b/llvm-mapper/src/block/type_table.rs
@@ -499,6 +499,6 @@ impl IrBlock for TypeTable {
             }
         }
 
-        Ok(partial_types.reify()?)
+        partial_types.reify()
     }
 }

--- a/llvm-mapper/src/block/type_table.rs
+++ b/llvm-mapper/src/block/type_table.rs
@@ -11,7 +11,7 @@ use num_enum::TryFromPrimitiveError;
 use thiserror::Error;
 
 use crate::block::{BlockMapError, IrBlock};
-use crate::map::MapCtx;
+use crate::map::PartialMapCtx;
 use crate::record::RecordMapError;
 use crate::unroll::UnrolledBlock;
 
@@ -265,7 +265,10 @@ impl TypeTable {
 impl IrBlock for TypeTable {
     const BLOCK_ID: IrBlockId = IrBlockId::Type;
 
-    fn try_map_inner(block: &UnrolledBlock, _ctx: &mut MapCtx) -> Result<Self, BlockMapError> {
+    fn try_map_inner(
+        block: &UnrolledBlock,
+        _ctx: &mut PartialMapCtx,
+    ) -> Result<Self, BlockMapError> {
         // Figure out how many type entries we have, and reserve the space for them up-front.
         let numentries = {
             let numentries = block.one_record(TypeCode::NumEntry as u64)?;

--- a/llvm-mapper/src/error.rs
+++ b/llvm-mapper/src/error.rs
@@ -12,14 +12,14 @@ use crate::block::BlockMapError;
 #[derive(Debug, ThisError)]
 pub enum Error {
     /// We encountered an error while performing the underlying bitstream parse.
-    #[error("error while parsing the bitstream: {0}")]
+    #[error("error while parsing the bitstream")]
     Parse(#[from] BitstreamError),
 
     /// We couldn't unroll the stream because of a structural error.
     #[error("error while unrolling the bitstream: {0}")]
-    BadUnroll(String),
+    Unroll(String),
 
-    /// We couldn't map a block, for some internal reason.
-    #[error("error while mapping block: {0}")]
-    BadBlock(#[from] BlockMapError),
+    /// We couldn't perform the bitstream map.
+    #[error("error while mapping the bitsteam")]
+    Map(#[from] BlockMapError),
 }

--- a/llvm-mapper/src/map.rs
+++ b/llvm-mapper/src/map.rs
@@ -118,9 +118,6 @@ impl MapCtx<'_> {
 pub(crate) trait PartialCtxMappable<T>: Sized {
     type Error;
 
-    // TODO(ww): This should declare an associated type for the error, instead
-    // of using the crate-wide Error.
-
     /// Attempt to map `T` into `Self` using the given [`PartialMapCtx`](PartialMapCtx).
     fn try_map(raw: &T, ctx: &mut PartialMapCtx) -> Result<Self, Self::Error>;
 }
@@ -133,9 +130,6 @@ pub(crate) trait PartialCtxMappable<T>: Sized {
 /// [`MapCtx`](MapCtx), which should only happen early in IR module parsing.
 pub(crate) trait CtxMappable<'ctx, T>: Sized {
     type Error;
-
-    // TODO(ww): This should declare an associated type for the error, instead
-    // of using the crate-wide Error.
 
     /// Attempt to map `T` into `Self` using the given [`MapCtx`](MapCtx).
     fn try_map(raw: &T, ctx: &'ctx MapCtx) -> Result<Self, Self::Error>;

--- a/llvm-mapper/src/map.rs
+++ b/llvm-mapper/src/map.rs
@@ -22,6 +22,46 @@ pub enum MapCtxError {
     NoTypeTable,
 }
 
+/// A mushy container for various bits of state that are necessary for
+/// correct block and record mapping in the context of a particular IR module.
+///
+/// This is the "partial" counterpart to the [`MapCtx`](MapCtx) structure,
+/// which is produced from this structure with a call to [`reify`](PartialMapCtx::reify).
+#[non_exhaustive]
+#[derive(Debug, Default)]
+pub(crate) struct PartialMapCtx {
+    pub(crate) version: Option<u64>,
+    pub(crate) strtab: Option<Strtab>,
+    pub(crate) attribute_groups: Option<AttributeGroups>,
+    pub(crate) attributes: Option<Attributes>,
+    pub(crate) type_table: Option<TypeTable>,
+}
+
+impl PartialMapCtx {
+    pub(crate) fn reify(&self) -> Result<MapCtx, MapCtxError> {
+        Ok(MapCtx {
+            version: self.version.ok_or(MapCtxError::NoVersion)?,
+            strtab: self.strtab.as_ref().ok_or(MapCtxError::NoStrtab)?,
+            attribute_groups: self
+                .attribute_groups
+                .as_ref()
+                .ok_or(MapCtxError::NoAttributeGroups)?,
+            attributes: self
+                .attributes
+                .as_ref()
+                .ok_or(MapCtxError::NoAttributeGroups)?,
+            type_table: self.type_table.as_ref().ok_or(MapCtxError::NoTypeTable)?,
+        })
+    }
+
+    /// Returns the attribute groups stored in this context, or an error if not available.
+    pub fn attribute_groups(&self) -> Result<&AttributeGroups, MapCtxError> {
+        self.attribute_groups
+            .as_ref()
+            .ok_or(MapCtxError::NoAttributeGroups)
+    }
+}
+
 /// A handle for various bits of state that are necessary for correct block
 /// and record mapping in the context of a particular IR module.
 ///
@@ -32,65 +72,71 @@ pub enum MapCtxError {
 /// Block and record mapping operations are expected to update the supplied context,
 /// as appropriate.
 #[non_exhaustive]
-#[derive(Debug, Default)]
-pub struct MapCtx {
-    // TODO(ww): Think harder about this struct. Maybe these should be non-Options, and
-    // the Mappable trait should instead take an Option<MapCtx>. Then, we'd prefill
-    // the MapCtx will all requisite state during the unroll phase, rather than deferring
-    // it to module creation. Is that better or worse?
-    pub(crate) version: Option<u64>,
-    pub(crate) strtab: Option<Strtab>,
-    pub(crate) attribute_groups: Option<AttributeGroups>,
-    pub(crate) attributes: Option<Attributes>,
-    pub(crate) type_table: Option<TypeTable>,
+#[derive(Debug)]
+pub struct MapCtx<'ctx> {
+    /// The `MODULE_CODE_VERSION` for the IR module being mapped.
+    pub version: u64,
+
+    /// The string table.
+    pub strtab: &'ctx Strtab,
+
+    /// Any attribute groups.
+    pub attribute_groups: &'ctx AttributeGroups,
+
+    /// Any raw attributes.
+    pub attributes: &'ctx Attributes,
+
+    /// The type table.
+    pub type_table: &'ctx TypeTable,
     // TODO(ww): Maybe symtab and identification in here?
 }
 
-impl MapCtx {
-    /// Returns the version stored in this context, or an error if no version is available.
-    pub fn version(&self) -> Result<u64, MapCtxError> {
-        self.version.ok_or(MapCtxError::NoVersion)
-    }
-
+impl MapCtx<'_> {
     /// A helper function for whether or not to use an associated string table for string lookups.
     ///
     /// This corresponds to `MODULE_CODE_VERSION`s of 2 and higher.
-    pub fn use_strtab(&self) -> Result<bool, MapCtxError> {
-        self.version().map(|v| v >= 2)
+    pub fn use_strtab(&self) -> bool {
+        self.version >= 2
     }
 
     /// A helper function for determining how operands are encoded.
     ///
     /// This corresponds to `MODULE_CODE_VERSION`s of 1 and higher.
-    pub fn use_relative_ids(&self) -> Result<bool, MapCtxError> {
-        self.version().map(|v| v >= 1)
-    }
-
-    /// Returns the string table stored in this context, or an error if no string table is available.
-    pub fn strtab(&self) -> Result<&Strtab, MapCtxError> {
-        self.strtab.as_ref().ok_or(MapCtxError::NoStrtab)
-    }
-
-    /// Returns the attribute groups stored in this context, or an error if not available.
-    pub fn attribute_groups(&self) -> Result<&AttributeGroups, MapCtxError> {
-        self.attribute_groups
-            .as_ref()
-            .ok_or(MapCtxError::NoAttributeGroups)
-    }
-
-    /// Returns the type table stored in this context, or an error if not available.
-    pub fn type_table(&self) -> Result<&TypeTable, MapCtxError> {
-        self.type_table.as_ref().ok_or(MapCtxError::NoTypeTable)
+    pub fn use_relative_ids(&self) -> bool {
+        self.version >= 1
     }
 }
 
 /// A trait for mapping some raw `T` into a model type.
-pub(crate) trait Mappable<T>: Sized {
+///
+/// This trait allows an implementer to modify the given [`PartialMapCtx`](PartialMapCtx),
+/// filling it in with state before it's reified into a "real" [`MapCtx`](MapCtx).
+///
+/// This two-stage process is designed to limit the number of invalid
+/// states that a `MapCtx` can be in, and to enable better lifetimes
+/// later in the IR module mapping process.
+pub(crate) trait PartialCtxMappable<T>: Sized {
+    type Error;
+
+    // TODO(ww): This should declare an associated type for the error, instead
+    // of using the crate-wide Error.
+
+    /// Attempt to map `T` into `Self` using the given [`PartialMapCtx`](PartialMapCtx).
+    fn try_map(raw: &T, ctx: &mut PartialMapCtx) -> Result<Self, Self::Error>;
+}
+
+/// A trait for mapping some raw `T` into a model type.
+///
+/// Implementing this trait is *almost* always preferable over
+/// [`PartialCtxMappable`](PartialCtxMappable) -- the former should really only
+/// be used when a mapping implementation **absolutely** must modify its
+/// [`MapCtx`](MapCtx), which should only happen early in IR module parsing.
+pub(crate) trait CtxMappable<'ctx, T>: Sized {
     type Error;
 
     // TODO(ww): This should declare an associated type for the error, instead
     // of using the crate-wide Error.
 
     /// Attempt to map `T` into `Self` using the given [`MapCtx`](MapCtx).
-    fn try_map(raw: &T, ctx: &mut MapCtx) -> Result<Self, Self::Error>;
+    fn try_map(raw: &T, ctx: &'ctx MapCtx) -> Result<Self, Self::Error>;
 }

--- a/llvm-mapper/src/map.rs
+++ b/llvm-mapper/src/map.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 use crate::block::Strtab;
 use crate::block::{AttributeGroups, Attributes, TypeTable};
+use crate::record::DataLayout;
 
 /// Errors that can occur when accessing a [`MapCtx`](MapCtx).
 #[derive(Debug, Error)]
@@ -31,6 +32,7 @@ pub enum MapCtxError {
 #[derive(Debug, Default)]
 pub(crate) struct PartialMapCtx {
     pub(crate) version: Option<u64>,
+    pub(crate) datalayout: DataLayout,
     pub(crate) strtab: Option<Strtab>,
     pub(crate) attribute_groups: Option<AttributeGroups>,
     pub(crate) attributes: Option<Attributes>,
@@ -41,6 +43,7 @@ impl PartialMapCtx {
     pub(crate) fn reify(&self) -> Result<MapCtx, MapCtxError> {
         Ok(MapCtx {
             version: self.version.ok_or(MapCtxError::NoVersion)?,
+            datalayout: &self.datalayout,
             strtab: self.strtab.as_ref().ok_or(MapCtxError::NoStrtab)?,
             attribute_groups: self
                 .attribute_groups
@@ -76,6 +79,9 @@ impl PartialMapCtx {
 pub struct MapCtx<'ctx> {
     /// The `MODULE_CODE_VERSION` for the IR module being mapped.
     pub version: u64,
+
+    /// The datalayout specification.
+    pub datalayout: &'ctx DataLayout,
 
     /// The string table.
     pub strtab: &'ctx Strtab,

--- a/llvm-mapper/src/map.rs
+++ b/llvm-mapper/src/map.rs
@@ -4,7 +4,38 @@ use thiserror::Error;
 
 use crate::block::Strtab;
 use crate::block::{AttributeGroups, Attributes, TypeTable};
-use crate::record::DataLayout;
+use crate::record::{DataLayout, RecordStringError};
+use crate::unroll::ConsistencyError;
+
+/// Generic errors that can occur when mapping.
+#[derive(Debug, Error)]
+pub enum MapError {
+    /// We couldn't map a block, for any number of reasons.
+    #[error("error while mapping block: {0}")]
+    BadBlockMap(String),
+
+    /// We encountered an inconsistent block or record state.
+    #[error("inconsistent block or record state")]
+    Inconsistent(#[from] ConsistencyError),
+
+    /// We encountered an unsupported feature or layout.
+    #[error("unsupported: {0}")]
+    Unsupported(String),
+
+    /// We encountered an invalid state or combination of states.
+    ///
+    /// This variant should be used extremely sparingly.
+    #[error("invalid: {0}")]
+    Invalid(String),
+
+    /// We couldn't extract a string from a record.
+    #[error("error while extracting string: {0}")]
+    RecordString(#[from] RecordStringError),
+
+    /// We don't have the appropriate context for a mapping operation.
+    #[error("missing context for mapping")]
+    Context(MapCtxError),
+}
 
 /// Errors that can occur when accessing a [`MapCtx`](MapCtx).
 #[derive(Debug, Error)]

--- a/llvm-mapper/src/record/comdat.rs
+++ b/llvm-mapper/src/record/comdat.rs
@@ -3,11 +3,33 @@
 use std::convert::TryInto;
 
 use llvm_support::StrtabRef;
-use num_enum::TryFromPrimitive;
+use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
+use thiserror::Error;
 
+use crate::block::strtab::StrtabError;
 use crate::map::{CtxMappable, MapCtx};
-use crate::record::RecordMapError;
 use crate::unroll::UnrolledRecord;
+
+/// Errors that can occur when mapping a COMDAT record.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum ComdatError {
+    /// The COMDAT record is in an old unsupported format.
+    #[error("unsupported COMDAT record format (v1)")]
+    V1Unsupported,
+
+    /// The COMDAT record is too short.
+    #[error("COMDAT record doesn't have enough fields ({0} < 3)")]
+    TooShort(usize),
+
+    /// We couldn't get the COMDAT's name from the string table.
+    #[error("error while accessing COMDAT name: {0}")]
+    Name(#[from] StrtabError),
+
+    /// The COMDAT's selection kind is invalid or unknown.
+    #[error("unknown or invalid COMDAT selection kind: {0}")]
+    SelectionKind(#[from] TryFromPrimitiveError<SelectionKind>),
+}
 
 /// The different kinds of COMDAT selections.
 ///
@@ -15,7 +37,7 @@ use crate::unroll::UnrolledRecord;
 #[non_exhaustive]
 #[derive(Debug, TryFromPrimitive)]
 #[repr(u64)]
-pub enum ComdatSelectionKind {
+pub enum SelectionKind {
     /// The linker may choose any COMDAT.
     Any,
     /// The data referenced by the COMDAT must be the same.
@@ -33,27 +55,22 @@ pub enum ComdatSelectionKind {
 #[derive(Debug)]
 pub struct Comdat<'ctx> {
     /// The selection kind for this COMDAT.
-    pub selection_kind: ComdatSelectionKind,
+    pub selection_kind: SelectionKind,
     /// The COMDAT key.
     pub name: &'ctx str,
 }
 
 impl<'ctx> CtxMappable<'ctx, UnrolledRecord> for Comdat<'ctx> {
-    type Error = RecordMapError;
+    type Error = ComdatError;
 
     fn try_map(record: &UnrolledRecord, ctx: &'ctx MapCtx) -> Result<Self, Self::Error> {
         if !ctx.use_strtab() {
-            return Err(RecordMapError::Unsupported(
-                "v1 COMDAT records are not supported".into(),
-            ));
+            return Err(ComdatError::V1Unsupported);
         }
 
         // v2: [strtab offset, strtab size, selection kind]
         if record.fields().len() != 3 {
-            return Err(RecordMapError::BadRecordLayout(format!(
-                "expected exactly 3 fields in COMDAT record, got {}",
-                record.fields().len()
-            )));
+            return Err(ComdatError::TooShort(record.fields().len()));
         }
 
         // Index safety: we check for at least 3 fields above.
@@ -61,9 +78,7 @@ impl<'ctx> CtxMappable<'ctx, UnrolledRecord> for Comdat<'ctx> {
             let sref: StrtabRef = (record.fields()[0], record.fields()[1]).into();
             ctx.strtab.try_get(&sref)?
         };
-        let selection_kind: ComdatSelectionKind = record.fields()[2].try_into().map_err(|e| {
-            RecordMapError::BadRecordLayout(format!("invalid COMDAT selection kind: {:?}", e))
-        })?;
+        let selection_kind: SelectionKind = record.fields()[2].try_into()?;
 
         Ok(Self {
             selection_kind,

--- a/llvm-mapper/src/record/datalayout.rs
+++ b/llvm-mapper/src/record/datalayout.rs
@@ -11,7 +11,7 @@ use llvm_support::{
 };
 use thiserror::Error;
 
-use crate::map::{MapCtx, Mappable};
+use crate::map::{PartialCtxMappable, PartialMapCtx};
 use crate::record::RecordStringError;
 use crate::unroll::UnrolledRecord;
 
@@ -250,10 +250,10 @@ impl FromStr for DataLayout {
     }
 }
 
-impl Mappable<UnrolledRecord> for DataLayout {
+impl PartialCtxMappable<UnrolledRecord> for DataLayout {
     type Error = DataLayoutParseError;
 
-    fn try_map(record: &UnrolledRecord, _ctx: &mut MapCtx) -> Result<Self, Self::Error> {
+    fn try_map(record: &UnrolledRecord, _ctx: &mut PartialMapCtx) -> Result<Self, Self::Error> {
         let datalayout = record.try_string(0)?;
         datalayout.parse::<Self>()
     }

--- a/llvm-mapper/src/record/function.rs
+++ b/llvm-mapper/src/record/function.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use crate::block::attributes::AttributeEntry;
 use crate::block::type_table::{TypeRef, TypeTableError};
-use crate::map::{CtxMappable, MapCtx, MapCtxError};
+use crate::map::{CtxMappable, MapCtx};
 use crate::record::StrtabError;
 use crate::unroll::UnrolledRecord;
 
@@ -23,10 +23,6 @@ pub enum FunctionError {
     /// The function record is in an old unsupported format.
     #[error("unsupported function record format (v1)")]
     V1Unsupported,
-
-    /// Our mapping context was invalid for our operation.
-    #[error("invalid mapping context: {0}")]
-    BadContext(#[from] MapCtxError),
 
     /// Retrieving a string from a string table failed.
     #[error("error while accessing string table: {0}")]
@@ -109,7 +105,7 @@ impl<'ctx> CtxMappable<'ctx, UnrolledRecord> for Function<'ctx> {
                 Some(
                     ctx.attributes
                         .get(paramattr - 1)
-                        .ok_or_else(|| FunctionError::BadAttribute(paramattr))?,
+                        .ok_or(FunctionError::BadAttribute(paramattr))?,
                 )
             }
         };

--- a/llvm-mapper/src/record/mod.rs
+++ b/llvm-mapper/src/record/mod.rs
@@ -55,13 +55,13 @@ pub enum RecordMapError {
 
     /// Parsing the datalayout specification failed.
     #[error("error while parsing datalayout: {0}")]
-    DataLayout(#[from] DataLayoutParseError),
+    DataLayout(#[from] DataLayoutError),
 
     /// Mapping a function record failed.
     #[error("error while mapping function record: {0}")]
     Function(#[from] FunctionError),
 
-    /// We encountered a string we couldn't parse.
-    #[error("error while parsing string: {0}")]
+    /// We encountered a string we couldn't extract.
+    #[error("error while extracting string: {0}")]
     BadRecordString(#[from] RecordStringError),
 }

--- a/llvm-mapper/src/record/mod.rs
+++ b/llvm-mapper/src/record/mod.rs
@@ -17,7 +17,7 @@ pub use self::comdat::*;
 pub use self::datalayout::*;
 pub use self::function::*;
 use crate::block::StrtabError;
-use crate::map::{MapCtxError, Mappable};
+use crate::map::MapCtxError;
 
 /// Potential errors when trying to extract a string from a record.
 #[non_exhaustive]

--- a/llvm-mapper/src/unroll.rs
+++ b/llvm-mapper/src/unroll.rs
@@ -92,7 +92,7 @@ impl UnrolledRecords {
         code: impl Into<u64> + 'a,
     ) -> impl Iterator<Item = &UnrolledRecord> + 'a {
         let code = code.into();
-        self.0.iter().filter(move |r| r.code() == code.into())
+        self.0.iter().filter(move |r| r.code() == code)
     }
 
     /// Returns the first record matching the given code, or `None` if there are

--- a/llvm-mapper/src/unroll.rs
+++ b/llvm-mapper/src/unroll.rs
@@ -87,8 +87,12 @@ impl UnrolledRecords {
     /// are iterated in the order of insertion.
     ///
     /// The returned iterator is empty if the block doesn't have any matching records.
-    pub(crate) fn by_code(&self, code: u64) -> impl Iterator<Item = &UnrolledRecord> + '_ {
-        self.0.iter().filter(move |r| r.code() == code)
+    pub(crate) fn by_code<'a>(
+        &'a self,
+        code: impl Into<u64> + 'a,
+    ) -> impl Iterator<Item = &UnrolledRecord> + 'a {
+        let code = code.into();
+        self.0.iter().filter(move |r| r.code() == code.into())
     }
 
     /// Returns the first record matching the given code, or `None` if there are

--- a/llvm-mapper/src/unroll.rs
+++ b/llvm-mapper/src/unroll.rs
@@ -11,7 +11,7 @@ use llvm_constants::IrBlockId;
 
 use crate::block::{BlockId, BlockMapError, Identification, Module, Strtab, Symtab};
 use crate::error::Error;
-use crate::map::{MapCtx, Mappable};
+use crate::map::{PartialCtxMappable, PartialMapCtx};
 use crate::record::{RecordMapError, RecordStringError};
 
 /// An "unrolled" record. This is internally indistinguishable from a raw bitstream
@@ -394,7 +394,7 @@ impl PartialBitcodeModule {
     /// Returns an error if the `PartialBitcodeModule` is lacking necessary state, or if
     /// block and record mapping fails for any reason.
     pub(self) fn reify(self) -> Result<BitcodeModule, Error> {
-        let mut ctx = MapCtx::default();
+        let mut ctx = PartialMapCtx::default();
 
         // Grab the string table early, so that we can move it into our mapping context and
         // use it for the remainder of the mapping phase.


### PR DESCRIPTION
WIP.

This splits `Mappable` into `CtxMappable` and `PartialCtxMappable`, corresponding to two ownership styles when mapping:

* `CtxMappable` takes a `&'ctx MapCtx` and can produce types that live as long as the `'ctx`
* `PartialCtxMappable` takes a `&mut PartialMapCtx` and can modify it internally, but can't produce types that live as long as it

Together, these two traits solve the copying and semantic problems identified in #18.