### PR TITLE
Fix wasm32 target bitcode would fail to parse

### DIFF
--- a/llvm-mapper/src/record/datalayout.rs
+++ b/llvm-mapper/src/record/datalayout.rs
@@ -213,6 +213,7 @@ impl FromStr for DataLayout {
                         Some('i') => {
                             datalayout.non_integral_address_spaces = body[1..]
                                 .split(':')
+                                .filter(|s| s.len() > 0)
                                 .map(|s| {
                                     s.parse::<u32>()
                                         .map_err(DataLayoutError::from)

--- a/llvm-mapper/src/record/datalayout.rs
+++ b/llvm-mapper/src/record/datalayout.rs
@@ -211,9 +211,13 @@ impl FromStr for DataLayout {
                     // 'n' marks the start of either an 'n' or an 'ni' block.
                     match body.chars().next() {
                         Some('i') => {
-                            datalayout.non_integral_address_spaces = body[1..]
+                            if body.len() <= 1 {
+                                return Err(DataLayoutError::BadSpecParse(
+                                    "cannot find address space 0".into(),
+                                ));
+                            }
+                            datalayout.non_integral_address_spaces = body[2..]
                                 .split(':')
-                                .filter(|s| s.len() > 0)
                                 .map(|s| {
                                     s.parse::<u32>()
                                         .map_err(DataLayoutError::from)
@@ -406,20 +410,20 @@ mod tests {
         }
 
         {
-            let dl = "ni1:2:3".parse::<DataLayout>().unwrap();
+            let dl = "ni:1:10:20".parse::<DataLayout>().unwrap();
 
             assert_eq!(
                 dl.non_integral_address_spaces,
                 vec![
                     AddressSpace::try_from(1_u32).unwrap(),
-                    AddressSpace::try_from(2_u32).unwrap(),
-                    AddressSpace::try_from(3_u32).unwrap()
+                    AddressSpace::try_from(10_u32).unwrap(),
+                    AddressSpace::try_from(20_u32).unwrap()
                 ]
             );
         }
 
         {
-            let dl = "ni1".parse::<DataLayout>().unwrap();
+            let dl = "ni:1".parse::<DataLayout>().unwrap();
 
             assert_eq!(
                 dl.non_integral_address_spaces,
@@ -430,12 +434,12 @@ mod tests {
         {
             assert_eq!(
                 "ni".parse::<DataLayout>().unwrap_err().to_string(),
-                "couldn't parse spec field: cannot parse integer from empty string"
+                "couldn't parse spec: cannot find address space 0"
             );
 
             assert_eq!(
                 "ni0".parse::<DataLayout>().unwrap_err().to_string(),
-                "couldn't parse spec: address space 0 cannot be non-integral"
+                "couldn't parse spec field: cannot parse integer from empty string"
             );
         }
     }


### PR DESCRIPTION
 Try to solve #55.
I found out the what cause the issue seems to be trying to parse `ni:1:10:20` when input file is the example provided in the issue. It removes `ni` and left `:1:10:20`, which split to `["", "1", "10", "20"]`, the `""` empty string fails to successfully parse  to u32 and result in `ParseIntError`.

So I filtered out empty string after split to prevent parsing empty string.

