### PR TITLE
#57 Reopen: mapper: Fix parse int attribute panic and support more attributes

### DIFF
--- a/llvm-mapper/src/block/attributes.rs
+++ b/llvm-mapper/src/block/attributes.rs
@@ -248,7 +248,7 @@ impl TryFrom<(AttributeId, u64)> for IntAttribute {
     fn try_from((key, value): (AttributeId, u64)) -> Result<Self, Self::Error> {
         // Test if it's an enum attribute. If it is, we know it can't be an integer attribute
         // and any fallthrough in our match below is unsupported rather than malformed.
-        if EnumAttribute::try_from(key).is_err() {
+        if EnumAttribute::try_from(key).is_ok() {
             return Err(AttributeError::AttributeMalformed(
                 "expected int attribute, but given enum ID",
                 key,
@@ -535,6 +535,7 @@ impl TryFrom<&'_ Block> for AttributeGroups {
             let mut fieldidx = 2;
             let mut attributes = vec![];
             while fieldidx < record.fields().len() {
+                // debug!("{:#?}", groups);
                 let (count, attr) = Attribute::from_record(fieldidx, record)?;
                 attributes.push(attr);
                 fieldidx += count;

--- a/llvm-mapper/src/block/attributes.rs
+++ b/llvm-mapper/src/block/attributes.rs
@@ -212,6 +212,16 @@ pub enum EnumAttribute {
     ElementType = AttributeId::ElementType as u64,
     /// `disable_sanitizer_instrumentation`
     DisableSanitizerInstrumentation = AttributeId::DisableSanitizerInstrumentation as u64,
+    /// ``allocalign`
+    AllocAlign = AttributeId::AllocAlign as u64,
+    /// `allocptr`
+    AllocatedPointer = AttributeId::AllocatedPointer as u64,
+    /// `presplitcoroutine`
+    PresplitCoroutine = AttributeId::PresplitCoroutine as u64,
+    /// `fn_ret_thunk_extern`
+    FnretthunkExtern = AttributeId::FnretthunkExtern as u64,
+    /// `skipprofile`
+    SkipProfile = AttributeId::SkipProfile as u64,
 }
 
 impl TryFrom<AttributeId> for EnumAttribute {
@@ -222,6 +232,18 @@ impl TryFrom<AttributeId> for EnumAttribute {
             .try_into()
             .map_err(|_| AttributeError::AttributeMalformed("non-enum attribute ID given", value))
     }
+}
+
+/// Represent unwind table variant
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive)]
+#[repr(u64)]
+pub enum UwTableVariant {
+    /// No unwind table requested
+    None = 0,
+    /// Synchronous unwinding table
+    Sync = 1,
+    /// Asynchronous unwinding table
+    Async = 2,
 }
 
 /// Represents an integral attribute, i.e. an attribute that carries (at least) one integer value with it.
@@ -240,6 +262,12 @@ pub enum IntAttribute {
     AllocSize(u32, Option<u32>),
     /// `vscale_range(<Min>[, <Max>])`
     VScaleRange(u32, u32),
+    /// `uwTable ([variant])`
+    UwTable(UwTableVariant),
+    /// `allockind (<KindBitset>)`
+    AllocKind(u64),
+    /// `memory (<memoryEffectBitset>)`
+    MemoryKind(u64),
 }
 
 impl TryFrom<(AttributeId, u64)> for IntAttribute {
@@ -248,7 +276,8 @@ impl TryFrom<(AttributeId, u64)> for IntAttribute {
     fn try_from((key, value): (AttributeId, u64)) -> Result<Self, Self::Error> {
         // Test if it's an enum attribute. If it is, we know it can't be an integer attribute
         // and any fallthrough in our match below is unsupported rather than malformed.
-        if EnumAttribute::try_from(key).is_ok() {
+        // UwTable is special because it is both enum attribute and integer attirbute
+        if EnumAttribute::try_from(key).is_ok() && key != AttributeId::UwTable {
             return Err(AttributeError::AttributeMalformed(
                 "expected int attribute, but given enum ID",
                 key,
@@ -314,6 +343,13 @@ impl TryFrom<(AttributeId, u64)> for IntAttribute {
 
                 IntAttribute::VScaleRange(max, min)
             }
+            AttributeId::UwTable => {
+                IntAttribute::UwTable(UwTableVariant::try_from(value).map_err(|_| {
+                    AttributeError::AttributeMalformed("Unwind table variant error", key)
+                })?)
+            }
+            AttributeId::AllocKind => IntAttribute::AllocKind(value),
+            AttributeId::Memory => IntAttribute::MemoryKind(value),
             o => return Err(AttributeError::IntAttributeUnsupported(o)),
         })
     }
@@ -387,6 +423,7 @@ impl Attribute {
             AttributeKind::Enum => {
                 // Enum attributes: one key field, nothing else.
                 let key = AttributeId::try_from(next!()?)?;
+                // TODO: deal with UwTable attribute's default value
                 Ok((fieldcount, Attribute::Enum(key.try_into()?)))
             }
             AttributeKind::IntKeyValue => {

--- a/llvm-support/src/attribute.rs
+++ b/llvm-support/src/attribute.rs
@@ -86,7 +86,7 @@ pub enum AttributeId {
     SanitizeThread = 31,
     /// `sanitize_memory`
     SanitizeMemory = 32,
-    /// `uwtable` ([variant])
+    /// `uwtable ([variant])`
     UwTable = 33,
     /// `zeroext`
     ZExt = 34,

--- a/llvm-support/src/attribute.rs
+++ b/llvm-support/src/attribute.rs
@@ -86,7 +86,7 @@ pub enum AttributeId {
     SanitizeThread = 31,
     /// `sanitize_memory`
     SanitizeMemory = 32,
-    /// `uwtable`
+    /// `uwtable` ([variant])
     UwTable = 33,
     /// `zeroext`
     ZExt = 34,
@@ -178,4 +178,20 @@ pub enum AttributeId {
     ElementType = 77,
     /// `disable_sanitizer_instrumentation`
     DisableSanitizerInstrumentation = 78,
+    /// `nosanitize_bounds`
+    NoSanitizeBounds = 79,
+    /// `allocalign`
+    AllocAlign = 80,
+    /// `allocptr`
+    AllocatedPointer = 81,
+    /// `allockind (<KindBitset>)`
+    AllocKind = 82,
+    /// `presplitcoroutine`
+    PresplitCoroutine = 83,
+    /// `fn_ret_thunk_extern`
+    FnretthunkExtern = 84,
+    /// `skipprofile`
+    SkipProfile = 85,
+    /// `memory (<LayoutBitset>)`
+    Memory = 86,
 }


### PR DESCRIPTION
See #57, it's an identical PR except I cherrypick the commits to main branch.